### PR TITLE
configurable-tcp-port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ redis_maxmem_policy: "allkeys-lfu"
 
 redis_addrs: []
 
+# TCP Port to listen on. Set to 0 to disable listening on a TCP socket.
+redis_port: 6379
+
 redis_protected: "no"
 
 redis_socket_path: "/var/run/redis/redis.sock"

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -95,7 +95,7 @@ protected-mode {{ redis_protected }}
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 6379
+port {{ redis_port }}
 
 # TCP listen() backlog.
 #


### PR DESCRIPTION
Make Redis TCP socket port configurable.

It is possible to set this to `0` in the Excision-Mail project later: Only `rspamd` daemon uses `redis` atm, and it accesses it via the configured unix socket, so a TCP socket is not strictly required. This is just a minor aesthetic change, but since Excision Mail claims to be "security focused", I thought I'd give it a shot!